### PR TITLE
feat: Replace Parser with Prism

### DIFF
--- a/dry_struct_rbs.gemspec
+++ b/dry_struct_rbs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_development_dependency 'dry-struct', '~> 1.0'
-  spec.add_development_dependency 'parser', '~> 3.0'
+  spec.add_development_dependency 'prism', '~> 1.4.0'
   spec.add_development_dependency 'rbs', '~> 3.0'
   spec.add_dependency 'unparser', '~> 0.6'
 

--- a/lib/dry_struct_rbs/generator.rb
+++ b/lib/dry_struct_rbs/generator.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'parser/current'
 require 'unparser'
 require 'fileutils'
 require 'rbs'
 require 'stringio'
+require 'prism'
 
 module DryStructRbs
   class Generator
@@ -47,9 +47,7 @@ module DryStructRbs
     end
 
     def parse_file(file_path)
-      buffer = Parser::Source::Buffer.new(file_path)
-      buffer.source = File.read(file_path)
-      Parser::CurrentRuby.new.parse(buffer)
+      Prism::Translation::Parser.parse_file(file_path)
     end
 
     def traverse_ast(node, file_path, namespace_stack = [], namespace_types = [])


### PR DESCRIPTION
Replace `parser` with `prism` as the `parser` gem will not be able to support ruby version 3.4 and above